### PR TITLE
Adding just any P3P header to satisfy IE when using Keycloak iFrame

### DIFF
--- a/puppet/manifests/apache.pp
+++ b/puppet/manifests/apache.pp
@@ -63,6 +63,8 @@ apache::vhost { 'keycloak.dukecon.org':
 	'reverse_urls'	=>	'http://localhost:9041/',
     },
   ],
+  # http://stackoverflow.com/questions/32120129/keycloak-is-causing-ie-to-have-an-infinite-loop
+  headers => 'set P3P "CP=\"Potato\""'
 }
 
 # SSL - there can be only one!


### PR DESCRIPTION
This tries to fix https://github.com/dukecon/dukecon_html5/issues/20 for Internet Explorer. I managed to add the P3P header using fiddler, and I reproduced a situation where it worked with the header, and didn't work without the header.
@ascheman - please merge and apply to the server. Please comment once it's on the server.
