### PR TITLE
add 'preferences' to the proxy

### DIFF
--- a/puppet/manifests/apache.pp
+++ b/puppet/manifests/apache.pp
@@ -180,12 +180,18 @@ if $hiera_dukecon_apache_ssl {
     request_headers       => [ 'set X-Forwarded-Proto https' ],
     proxy_preserve_host   => 'true',
     proxy_pass_match      => [
-      # The following looks a little bit strange - but for some reason it resolves https://github.com/dukecon/dukecon_infra/issues/28
+      # the target URL needs to have a replacement, otherwise the original path will be appended - looks strange, but works
+      # https://github.com/dukecon/dukecon_infra/issues/28
       { 'path' => '^/pwa/(\w+)/(\d+)/rest/(keycloak).json$',
         'url'  => 'http://localhost:9050/rest/$3.json',
       },
       { 'path' => '^/pwa/(\w+)/(\d+)/rest/(image-resources|init).json',
         'url'  => 'http://localhost:9050/rest/$3/$1/$2',
+      },
+      # the target URL needs to have a replacement, otherwise the original path will be appended - looks strange, but works
+      # https://github.com/dukecon/dukecon_infra/issues/28
+      { 'path' => '^/pwa/(\w+)/(\d+)/rest/(preferences)',
+        'url'  => 'http://localhost:9050/rest/$3',
       },
       { 'path' => '^/pwa/(\w+)/(\d+)/rest/conferences/(\w+)',
         'url'  => 'http://localhost:9050/rest/conferences/$3',


### PR DESCRIPTION
The URL https://latest.dukecon.org/pwa/javaland/2018/rest/preferences currently returns "404". After this change it should forward the request properly to the Java backend. 

After the change is in effect, opening the URL in a browser will redirect to Keycloak to ask for authentication. When used from the HTML5 there will be a bearer token and no redirect.

@ascheman - could you please merge, deploy and test? Thanks!

This is needed to complete https://github.com/dukecon/dukecon_pwa/issues/15