### PR TITLE
make also the styles CSS URL work

### DIFF
--- a/puppet/manifests/apache.pp
+++ b/puppet/manifests/apache.pp
@@ -187,7 +187,7 @@ if $hiera_dukecon_apache_ssl {
       { 'path' => '^/pwa/(\w+)/(\d+)/rest/(image-resources|init).json',
         'url'  => 'http://localhost:9050/rest/$3/$1/$2',
       },
-      { 'path' => '^/pwa/(\w+)/(\d+)/rest/conferences/(\w+)',
+      { 'path' => '^/pwa/(\w+)/(\d+)/rest/conferences/(.+)',
         'url'  => 'http://localhost:9050/rest/conferences/$3',
       },
       { 'path' => '^/pwa/(\w+)/(\d+)/rest/speaker/images/(\w+)',


### PR DESCRIPTION
The URL https://latest.dukecon.org/javaland/2018/rest/conferences/javaland2018/styles.css shows the CSS of the conference. The URL https://latest.dukecon.org/pwa/javaland/2018/rest/conferences/javaland2018/styles.css shows currently only the conference JSON, anything after the word is stripped -> I changed "\w" to "."